### PR TITLE
Support flags

### DIFF
--- a/packages/support-flags/--help/README.md
+++ b/packages/support-flags/--help/README.md
@@ -1,0 +1,1 @@
+# Add `--help` flag to your design, we will show what you can do with it on assistant.

--- a/packages/support-flags/README.md
+++ b/packages/support-flags/README.md
@@ -1,0 +1,4 @@
+# Flags support for assistant
+
+Assistant flag support extends `@design-sdk/flags` and `@code-features/flags` by default.
+We majorly support flag as a interactive helper for designers / developers.


### PR DESCRIPTION
# Flags support for assistant

Assistant flag support extends `@design-sdk/flags` and `@code-features/flags` by default.
We majorly support flag as a interactive helper for designers / developers.
